### PR TITLE
Use Chronos extension if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,20 @@ https://github.com/d954mas/defold-utf8/archive/master.zip
 The Log module automatically detects the presence of the native UTF8 extension and uses it if available. If the extension is not present, the Log module will use the built-in string functions.
 
 
+### Using High Resolution Timer Extension
+
+The Log module can utilize the Chronos extension for Defold to enable time tracking with microsecond or better precision (`QueryPerformanceCounter` on Windows). This is optional.
+
+If you want to use the extension, add the following line to the dependencies field in your `game.project` file:
+
+**[defold-chronos](https://github.com/d954mas/defold-chronos/archive/refs/tags/1.0.1.zip)**
+```
+https://github.com/d954mas/defold-chronos/archive/refs/tags/1.0.1.zip
+```
+
+The Log module automatically detects the presence of the extension and uses it if available. If the extension is not present, the Log module will use the built-in `socket.gettime` function.
+
+
 ## API Documentation
 
 ### Setup and Initialization

--- a/game.project
+++ b/game.project
@@ -17,6 +17,7 @@ version = 1
 publisher = Insality
 developer = Maksim Tuprikov, Insality
 dependencies#0 = https://github.com/d954mas/defold-utf8/archive/master.zip
+dependencies#1 = https://github.com/d954mas/defold-chronos/archive/refs/tags/1.0.1.zip
 
 [library]
 include_dirs = log


### PR DESCRIPTION
⚠️ Only tested on Windows

I'm not sure why you `floor` the time diff.
```
local diff_time = math.floor((current_time - self._last_message_time) * 1000000) / 1000
```
I would expect `string.format` to round the value properly. But since I can't seem to get any sub millisecond timestamps from `socket.gettime` (on Windows), I have a hard time verifying it. For me, it appears to work fine to skip `floor`, and with Chronos, doing the above will reduce the displayed resolution.

I also moved the "get time" call to before the memory formatting block. This reduces the measured time elapsed since the last message with about 0.0014ms. The lowest elapsed time between messages I get now is 0.0002ms.